### PR TITLE
Note on pip installation

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -48,24 +48,33 @@ programming language.  Currently. QuTiP requires the following packages to run:
 +----------------+--------------+-----------------------------------------------------+
 
 |
-On all platforms (Linux, Mac, Windows), QuTiP works "out-of-the-box" using the `Anaconda CE <https://store.continuum.io/cshop/anaconda>`_.  This distribution is created by the developers of Numpy, and is free for both commercial and noncommercial use.
+On all platforms (Linux, Mac, Windows), QuTiP works "out-of-the-box" using the `Anaconda CE <https://store.continuum.io/cshop/anaconda>`_. This distribution is created by the developers of Numpy, and is free for both commercial and noncommercial use.
 
 As of version 2.2, QuTiP includes an optional Fortran-based Monte Carlo solver that has a substantial performance benefit when compared with the Python-based solver. In order to install this package you must have a Fortran compiler (for example gfortran) and BLAS development libraries.  At present, these packages are only tested on the Linux and OS X platforms.
 
-Given other requirements are fulfilled, the easiest way is to install QuTip is with [pip](http://www.pip-installer.org/), the Python package manager
+
+.. _install-platform-independent:
+
+Platform-independent installation
+=================================
+
+Often the easiest way is to install QuTiP is to use the Python package manager `pip <http://www.pip-installer.org/>`_.
+
 
     $ sudo pip install qutip
 
-Alternatively...
+
+However, when installing QuTiP this way the Fortran-based Monte Carlo solver is not included.
+More detailed platform-dependent installation alternatives are given below.
 
 .. _install-get-it:
 
-Get the software
-================
+Get the source code
+===================
 
 Official releases of QuTiP are available from the download section on the project's web pages
 
-    http://code.google.com/p/qutip/downloads
+    http://www.qutip.org/download.html
 
 and the latest source code is available in our Github repository
 


### PR DESCRIPTION
Here is a note on installation of QuTip with [pip](http://www.pip-installer.org), that is, from https://pypi.python.org/pypi/qutip.

The good thing about pip is that, given other requirements are fulfilled (and people using Python for any kind of science usually already have the [SciPy](http://www.scipy.org/) stack), it is just one command, being system-independent. (Plus, it is a package manager, so it is easy to install, uninstall, upgrade, ...)

However, I am not sure, if the inclusion fits the style & structure of the installation instructions.
