### PR TITLE
Documentation for new random qobj support.

### DIFF
--- a/apidoc/functions.rst
+++ b/apidoc/functions.rst
@@ -30,7 +30,7 @@ Random Operators and States
 ---------------------------
 
 .. automodule:: qutip.random_objects
-    :members: rand_dm, rand_herm, rand_ket, rand_unitary
+    :members: rand_dm, rand_dm_ginibre, rand_dm_hs, rand_herm, rand_ket, rand_ket_haar, rand_unitary, rand_unitary_haar, rand_super, rand_super_bcsz
 
 
 Three-Level Atoms

--- a/biblio.rst
+++ b/biblio.rst
@@ -3,6 +3,9 @@
 Bibliography
 ============
 
+.. [BCSZ08]
+    W. Bruzda, V. Cappellini, H.-J. Sommers, K. Życzkowski, *Random Quantum Operations*, Phys. Lett. A **373**, 320-324 (2009). :doi:`10.1016/j.physleta.2008.11.043`.
+
 .. [Hav03]
     Havel, T. *Robust procedures for converting among Lindblad, Kraus and matrix representations of quantum dynamical semigroups*. Journal of Mathematical Physics **44** 2, 534 (2003). :doi:`10.1063/1.1518555`.
 
@@ -14,6 +17,12 @@ Bibliography
     
 .. |theory-qi| replace:: *Theory of Quantum Information*
 .. _theory-qi: https://cs.uwaterloo.ca/~watrous/CS766/
+
+.. [Mez07]
+    F. Mezzadri, *How to generate random matrices from the classical compact groups*, Notices of the AMS **54** 592-604 (2007). :arxiv:`math-ph/0609050`.
+
+.. [Mis12]
+    J. A. Miszczak, *Generating and using truly random quantum states in Mathematica*, Computer Physics Communications **183** 1, 118-124 (2012). :doi:`10.1016/j.cpc.2011.08.002`.
 
 .. [Moh08]
     M. Mohseni, A. T. Rezakhani, D. A. Lidar, *Quantum-process tomography: Resource analysis of different strategies*, Phys. Rev. A **77**, 032322 (2008). :doi:`10.1103/PhysRevA.77.032322`.

--- a/guide/guide-random.rst
+++ b/guide/guide-random.rst
@@ -12,37 +12,41 @@ Generating Random Quantum States & Operators
 
    In [1]: from qutip import *
 
-QuTiP includes a collection of random state generators for simulations, theorem evaluation, and code testing:
+QuTiP includes a collection of random state, unitary and channel generators for simulations, Monte Carlo evaluation, theorem evaluation, and code testing.
+Each of these objects can be sampled from one of several different distributions including the default distributions
+used by QuTiP versions prior to 3.2.0.
+
+For example, a random Hermitian operator can be sampled by calling `rand_herm` function:
+
+.. ipython::
+
+	In [2]: rand_herm(5)
 
 .. tabularcolumns:: | p{2cm} | p{3cm} |
 
 .. cssclass:: table-striped
 
-+-------------------------------+---------------------------------+
-| Function                      | Description                     |
-+===============================+=================================+
-| `rand_ket`                    | Random ket-vector               |
-+-------------------------------+---------------------------------+
-| `rand_dm`                     | Random density matrix           |
-+-------------------------------+---------------------------------+
-| `rand_herm`                   | Random Hermitian matrix         |
-+-------------------------------+---------------------------------+
-| `rand_unitary`                | Random Unitary matrix           |
-+-------------------------------+---------------------------------+
+===========================   ========================================== ========================================
+Random Variable Type          Sampling Functions                         Dimensions
+===========================   ========================================== ========================================
+State vector (``ket``)        `rand_ket`, `rand_ket_haar`                :math:`N \times 1`
+Hermitian operator (``oper``) `rand_herm`                                :math:`N \times 1`
+Density operator (``oper``)   `rand_dm`, `rand_dm_hs`, `rand_dm_ginibre` :math:`N \times N`
+Unitary operator (``oper``)   `rand_unitary`, `rand_unitary_haar`        :math:`N \times N`
+CPTP channel (``super``)      `rand_super`, `rand_super_bcsz`            :math:`(N \times N) \times (N \times N)`
+===========================   ========================================== ========================================
 
+In all cases, these functions can be called with a single parameter :math:`N` that dimension of the relevant Hilbert space. The optional
+``dims`` keyword argument allows for the dimensions of a random state, unitary or channel to be broken down into subsystems.
+
+.. ipython::
+	
+	In [3]: print rand_super_bcsz(7).dims
+
+	In [4]: print rand_super_bcsz(6, dims=[[[2, 3], [2, 3]], [[2, 3], [2, 3]]]).dims
+	
 See the API documentation: :ref:`functions-rand` for details.
 
-In all cases, these functions can be called with a single parameter :math:`N` that indicates a :math:`NxN` matrix (`rand_dm`, `rand_herm`, `rand_unitary`), or a :math:`Nx1` vector (`rand_ket`), should be generated.  For example:
-
-.. ipython::
-
-   In [1]: rand_ket(5)
-
-or
-
-.. ipython::
-
-   In [1]: rand_herm(5)
 
 In this previous example, we see that the generated Hermitian operator contains a fraction of elements that are identically equal to zero.  The number of nonzero elements is called the `density` and can be controlled by calling any of the random state/operator generators with a second argument between 0 and 1.  By default, the density for the operators is `0.75` where as ket vectors are completely dense (`1`).  For example:
 

--- a/guide/guide-random.rst
+++ b/guide/guide-random.rst
@@ -26,15 +26,19 @@ For example, a random Hermitian operator can be sampled by calling `rand_herm` f
 
 .. cssclass:: table-striped
 
-===========================   ========================================== ========================================
-Random Variable Type          Sampling Functions                         Dimensions
-===========================   ========================================== ========================================
-State vector (``ket``)        `rand_ket`, `rand_ket_haar`                :math:`N \times 1`
-Hermitian operator (``oper``) `rand_herm`                                :math:`N \times 1`
-Density operator (``oper``)   `rand_dm`, `rand_dm_hs`, `rand_dm_ginibre` :math:`N \times N`
-Unitary operator (``oper``)   `rand_unitary`, `rand_unitary_haar`        :math:`N \times N`
-CPTP channel (``super``)      `rand_super`, `rand_super_bcsz`            :math:`(N \times N) \times (N \times N)`
-===========================   ========================================== ========================================
++-------------------------------+--------------------------------------------+------------------------------------------+
+| Random Variable Type          | Sampling Functions                         | Dimensions                               |
++===============================+============================================+==========================================+
+| State vector (``ket``)        | `rand_ket`, `rand_ket_haar`                | :math:`N \times 1`                       |
++-------------------------------+--------------------------------------------+------------------------------------------+
+| Hermitian operator (``oper``) | `rand_herm`                                | :math:`N \times 1`                       |
++-------------------------------+--------------------------------------------+------------------------------------------+
+| Density operator (``oper``)   | `rand_dm`, `rand_dm_hs`, `rand_dm_ginibre` | :math:`N \times N`                       |
++-------------------------------+--------------------------------------------+------------------------------------------+
+| Unitary operator (``oper``)   | `rand_unitary`, `rand_unitary_haar`        | :math:`N \times N`                       |
++-------------------------------+--------------------------------------------+------------------------------------------+
+| CPTP channel (``super``)      | `rand_super`, `rand_super_bcsz`            | :math:`(N \times N) \times (N \times N)` |
++-------------------------------+--------------------------------------------+------------------------------------------+
 
 In all cases, these functions can be called with a single parameter :math:`N` that dimension of the relevant Hilbert space. The optional
 ``dims`` keyword argument allows for the dimensions of a random state, unitary or channel to be broken down into subsystems.
@@ -44,31 +48,35 @@ In all cases, these functions can be called with a single parameter :math:`N` th
 	In [3]: print rand_super_bcsz(7).dims
 
 	In [4]: print rand_super_bcsz(6, dims=[[[2, 3], [2, 3]], [[2, 3], [2, 3]]]).dims
-	
-See the API documentation: :ref:`functions-rand` for details.
 
+Several of the distributions supported by QuTiP support additional parameters as well, namely *density* and *rank*. In particular,
+the `rand_herm` and `rand_dm` functions return quantum objects such that a fraction of the elements are identically equal to zero.
+The ratio of nonzero elements is passed as the ``density`` keyword argument. By contrast, the `rand_dm_ginibre` and
+`rand_super_bcsz` take as an argument the rank of the generated object, such that passing ``rank=1`` returns a random
+pure state or unitary channel, respectively. Passing ``rank=None`` specifies that the generated object should be
+full-rank for the given dimension.
 
-In this previous example, we see that the generated Hermitian operator contains a fraction of elements that are identically equal to zero.  The number of nonzero elements is called the `density` and can be controlled by calling any of the random state/operator generators with a second argument between 0 and 1.  By default, the density for the operators is `0.75` where as ket vectors are completely dense (`1`).  For example:
+For example,
 
 .. ipython::
 
-   In [1]: rand_dm(5, 0.5)
+   In [5]: rand_dm(5, density=0.5)
 
-
-has roughly half nonzero elements, or equivalently a density of 0.5.
+   In [6]: rand_dm_ginibre(5, rank=2)
+	
+See the API documentation: :ref:`functions-rand` for details.
 
 .. warning::  
 
-    In the case of a density matrix, setting the density too low will result in     not enough diagonal elements to satisfy :math:`Tr(\rho)=1`.
+    When using the ``density`` keyword argument, setting the density too low may result in not enough diagonal elements to satisfy trace
+    constraints.
 
 Composite random objects
 ========================
 
 In many cases, one is interested in generating random quantum objects that correspond to composite systems generated using the :func:`qutip.tensor.tensor` function.  Specifying the tensor structure of a quantum object is done using the `dims` keyword argument in the same fashion as one would do for a :class:`qutip.Qobj` object:
 
-
 .. ipython::
 
    In [1]: rand_dm(4, 0.5, dims=[[2,2], [2,2]])
-
 


### PR DESCRIPTION
This PR introduces new documentation to match qutip/qutip#316. Currently, only new bibliography entries are present, but as the basic PR is completed, I will also revise ``guide-random.rst`` accordingly.