### PR TITLE
Support for Windows-based doc builds.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force Windows batch files to use \r\n.
+*.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Build requirements
 Build
 -----
 
-To build the documentation run:
+To build the documentation on Linux or OS X run:
 
-    $ make html pdflatex
+    $ make html latexpdf
+
+Building Documentation On Windows
+---------------------------------
+
+Building the HTML documentation requires Sphinx and numpydoc, both of which can be installed using Anaconda:
+
+    > conda install sphinx numpydoc
+
+If you installed QuTiP using another distribution of Python, these dependencies can also be installed using either ``easy_install`` or ``pip``:
+
+    > easy_install install sphinx numpydoc
+    > pip install sphinx numpydoc
+
+To build the HTML documentation on Windows using ``cmd.exe``, run:
+
+    > make html
+
+From PowerShell, run:
+
+    PS> .\make html

--- a/guide/dynamics/dynamics-monte.rst
+++ b/guide/dynamics/dynamics-monte.rst
@@ -217,6 +217,7 @@ Fortran Based Monte Carlo Solver
 In performing time-independent Monte Carlo simulations with QuTiP, systems with small Hilbert spaces suffer from poor performance as the ODE solver must exit the ODE solver at each time step and check for the state vector norm.  To correct this, QuTiP now includes an optional Fortran based Monte Carlo solver that has enhanced performance for systems with small Hilbert space dimensionality.  Using the Fortran based solver is extremely simple; one just needs to replace ``mcsolve`` with ``mcsolve_f90``.  For example, from our previous demonstration
 
 .. ipython::
+    :okexcept:
 
     In [1]: data1 = mcsolve_f90(H, psi0, times, [np.sqrt(0.1) * a], [a.dag() * a, sm.dag() * sm])
 

--- a/guide/dynamics/dynamics-time.rst
+++ b/guide/dynamics/dynamics-time.rst
@@ -14,6 +14,8 @@ Solving Problems with Time-dependent Hamiltonians
    
    In [1]: from pylab import *
 
+   In [1]: from warnings import warn
+
 
 Methods for Writing Time-Dependent Operators
 ============================================
@@ -117,13 +119,13 @@ As an example, we will look at an example that has a time-dependent Hamiltonian 
 Given that we have a single time-dependent Hamiltonian term, and constant collapse terms, we need to specify a single Python function for the coefficient :math:`f(t)`.  In this case, one can simply do
 
 .. ipython::
-    
+
     In [1]: def H1_coeff(t, args):
        ...:     return 9 * np.exp(-(t / 5.) ** 2)
 
 In this case, the return value dependents only on time.  However, when specifying Python functions for coefficients, **the function must have (t,args) as the input variables, in that order**.  Having specified our coefficient function, we can now specify the Hamiltonian in list format and call the solver (in this case :func:`qutip.mesolve`)
 
-.. ipython::
+.. ipython-posix::
 
     In [1]: H = [H0,[H1,H1_coeff]]
     
@@ -131,14 +133,14 @@ In this case, the return value dependents only on time.  However, when specifyin
 
 We can call the Monte Carlo solver in the exact same way (if using the default ``ntraj=500``):
 
-.. ipython::
+.. ipython-posix::
 
     In [1]: output = mcsolve(H, psi0, t, c_ops, [ada, sigma_UU, sigma_GG])
 
 The output from the master equation solver is identical to that shown in the examples, the Monte Carlo however will be noticeably off, suggesting we should increase the number of trajectories for this example.  In addition, we can also consider the decay of a simple Harmonic oscillator with time-varying decay rate
 
 .. ipython::
-    
+
     In [1]: kappa = 0.5
     
     In [1]: def col_coeff(t, args):  # coefficient function
@@ -177,16 +179,15 @@ or equivalently,
        ...:     sig = args['sigma']
        ...:     return A * np.exp(-(t / sig) ** 2)
 
-
 where args is a Python dictionary of ``key: value`` pairs ``args = {'A': a, 'sigma': b}`` where ``a`` and ``b`` are the two parameters for the amplitude and width, respectively.  Of course, we can always hardcode the values in the dictionary as well ``args = {'A': 9, 'sigma': 5}``, but there is much more flexibility by using variables in ``args``.  To let the solvers know that we have a set of args to pass we append the ``args`` to the end of the solver input:
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: output = mesolve(H, psi0, times, c_ops, [a.dag() * a], args={'A': 9, 'sigma': 5})
 
 or to keep things looking pretty
 
-.. ipython::
+.. ipython-posix::
 
     In [1]: args = {'A': 9, 'sigma': 5}
     
@@ -255,25 +256,26 @@ Like the previous method, the string-based format uses a list pair format ``[Op,
    In [1]: H1 = (sigma_ue.dag() + sigma_ue)  # time-dependent term
 
 
-.. ipython::
-    
+.. ipython-posix::
+
    In [1]: H = [H0, [H1, '9 * exp(-(t / 5) ** 2)']]
 
 Notice that this is a valid Hamiltonian for the string-based format as ``exp`` is included in the above list of suitable functions. Calling the solvers is the same as before:
 
-.. ipython::
+.. ipython-posix::
     
    In [1]: output = mesolve(H, psi0, t, c_ops, [a.dag() * a])
 
 We can also use the ``args`` variable in the same manner as before, however we must rewrite our string term to read: ``'A * exp(-(t / sig) ** 2)'``
 
-.. ipython::
+.. ipython-posix::
 
     In [1]: H = [H0, [H1, 'A * exp(-(t / sig) ** 2)']]
     
     In [1]: args = {'A': 9, 'sig': 5}
     
     In [1]: output = mesolve(H, psi0, times, c_ops, [a.dag()*a], args=args)
+
 
 .. important:: Naming your ``args`` variables ``e``, ``j`` or ``pi`` will cause errors when using the string-based format.
 
@@ -287,7 +289,7 @@ Reusing Time-Dependent Hamiltonian Data
 
 When repeatedly simulating a system where only the time-dependent variables, or initial state change, it is possible to reuse the Hamiltonian data stored in QuTiP and there by avoid spending time needlessly preparing the Hamiltonian and collapse terms for simulation.  To turn on the the reuse features, we must pass a :class:`qutip.Options` object with the ``rhs_reuse`` flag turned on.  Instructions on setting flags are found in :ref:`Options`.  For example, we can do
 
-.. ipython::
+.. ipython-posix::
 
     In [1]: H = [H0, [H1, 'A * exp(-(t / sig) ** 2)']]
     
@@ -300,7 +302,6 @@ When repeatedly simulating a system where only the time-dependent variables, or 
     In [1]: args = {'A': 10, 'sig': 3}
     
     In [1]: output = mcsolve(H, psi0, times, c_ops, [a.dag()*a], args=args, options=opts)
-	
 
 The second call to :func:`qutip.mcsolve` does not reorganize the data, and in the case of the string format, does not recompile the Cython code.  For the small system here, the savings in computation time is quite small, however, if you need to call the solvers many times for different parameters, this savings will obviously start to add up.
 

--- a/guide/guide-parfor.rst
+++ b/guide/guide-parfor.rst
@@ -20,7 +20,7 @@ Often one is interested in the output of a given function as a single-parameter 
 To use the these functions we need to define a function of one or more variables, and the range over which one of these variables are to be evaluated. For example:
 
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: def func1(x): return x, x**2, x**3
    
@@ -34,7 +34,7 @@ To use the these functions we need to define a function of one or more variables
    
 or
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: result = parallel_map(func1, range(10))
    
@@ -50,7 +50,7 @@ or
 Note that the return values are arranged differently for the :func:`qutip.parallel.parallel_map` and the :func:`qutip.parallel.parfor` functions, as illustrated below. In particular, the return value of :func:`qutip.parallel.parallel_map` is not enforced to be NumPy arrays, which can avoid unnecessary copying if all that is needed is to iterate over the resulting list:
 
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: result = parfor(func1, range(5))
    
@@ -62,7 +62,7 @@ Note that the return values are arranged differently for the :func:`qutip.parall
 
 The :func:`qutip.parallel.parallel_map` and :func:`qutip.parallel.parfor` functions are not limited to just numbers, but also works for a variety of outputs:
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: def func2(x): return x, Qobj(x), 'a' * x
    
@@ -82,7 +82,7 @@ The :func:`qutip.parallel.parallel_map` and :func:`qutip.parallel.parfor` functi
 One can also define functions with **multiple** input arguments and even keyword arguments. Here the :func:`qutip.parallel.parallel_map` and :func:`qutip.parallel.parfor` functions behaves differently:
 While :func:`qutip.parallel.parallel_map` only iterate over the values `arguments`, the :func:`qutip.parallel.parfor` function simultaneously iterates over all arguments:
 
-.. ipython::
+.. ipython-posix::
     
     In [1]: def sum_diff(x, y, z=0): return x + y, x - y, z
     
@@ -94,7 +94,7 @@ Note that the keyword arguments can be anything you like, but the keyword values
 
 The :func:`qutip.parallel.parallel_map` function also supports progressbar, using the keyword argument `progress_bar` which can be set to `True` or to an instance of :class:`qutip.ui.progressbar.BaseProgressBar`. There is a function called :func:`qutip.parallel.serial_map` that works as a non-parallel drop-in replacement for :func:`qutip.parallel.parallel_map`, which allows easy switching between serial and parallel computation.
 
-.. ipython::
+.. ipython-posix::
 
    In [1]: import time
 

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,179 @@
+@ECHO OFF
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set BUILDDIR=HEAD
+set TEXIFY=texify
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+if NOT "%PAPER%" == "" (
+	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
+)
+
+if "%1" == "" goto help
+
+if "%1" == "help" (
+	:help
+	echo.Please use `make ^<target^>` where ^<target^> is one of
+	echo.  html       to make standalone HTML files
+	echo.  dirhtml    to make HTML files named index.html in directories
+	echo.  singlehtml to make a single large HTML file
+	echo.  pickle     to make pickle files
+	echo.  json       to make JSON files
+	echo.  htmlhelp   to make HTML files and a HTML help project
+	echo.  qthelp     to make HTML files and a qthelp project
+	echo.  devhelp    to make HTML files and a Devhelp project
+	echo.  epub       to make an epub
+	echo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
+	echo.  text       to make text files
+	echo.  man        to make manual pages
+	echo.  changes    to make an overview over all changed/added/deprecated items
+	echo.  linkcheck  to check all external links for integrity
+	echo.  doctest    to run all doctests embedded in the documentation if enabled
+	goto end
+)
+
+if "%1" == "clean" (
+	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
+	del /q /s %BUILDDIR%\*
+	goto end
+)
+
+if "%1" == "html" (
+	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+	goto end
+)
+
+if "%1" == "dirhtml" (
+	%SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
+	goto end
+)
+
+if "%1" == "singlehtml" (
+	%SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
+	goto end
+)
+
+if "%1" == "pickle" (
+	%SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can process the pickle files.
+	goto end
+)
+
+if "%1" == "json" (
+	%SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can process the JSON files.
+	goto end
+)
+
+if "%1" == "htmlhelp" (
+	%SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can run HTML Help Workshop with the ^
+.hhp project file in %BUILDDIR%/htmlhelp.
+	goto end
+)
+
+if "%1" == "qthelp" (
+	%SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; now you can run "qcollectiongenerator" with the ^
+.qhcp project file in %BUILDDIR%/qthelp, like this:
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\QInfer.qhcp
+	echo.To view the help file:
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\QInfer.ghc
+	goto end
+)
+
+if "%1" == "devhelp" (
+	%SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished.
+	goto end
+)
+
+if "%1" == "epub" (
+	%SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The epub file is in %BUILDDIR%/epub.
+	goto end
+)
+
+if "%1" == "latex" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
+	goto end
+)
+
+if "%1" == "latexpdf" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	@echo "Running LaTeX files through texify..."
+	cd %BUILDDIR%/latex
+	$(TEXIFY) -b --pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+)
+
+if "%1" == "text" (
+	%SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The text files are in %BUILDDIR%/text.
+	goto end
+)
+
+if "%1" == "man" (
+	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The manual pages are in %BUILDDIR%/man.
+	goto end
+)
+
+if "%1" == "changes" (
+	%SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.The overview file is in %BUILDDIR%/changes.
+	goto end
+)
+
+if "%1" == "linkcheck" (
+	%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Link check complete; look for any errors in the above output ^
+or in %BUILDDIR%/linkcheck/output.txt.
+	goto end
+)
+
+if "%1" == "doctest" (
+	%SPHINXBUILD% -b doctest -t nomock %ALLSPHINXOPTS% %BUILDDIR%/doctest
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Testing of doctests in the sources finished, look at the ^
+results in %BUILDDIR%/doctest/output.txt.
+	goto end
+)
+
+:end


### PR DESCRIPTION
This PR adds support for building QuTiP docs from Windows. Due to subtle issues with multiprocessing on Windows, documentation examples that call ``parfor``, ``mcsolve`` or ``mesolve`` do not work on that platform. Thus, this PR also adds a new directive, ``ipython-posix``, that only runs its argument when built from a POSIX-platform (this is a workaround for ipython/ipython#9339; a more robust solution would depend on ``only`` or ``ifconfig``). Finally, this PR suppresses extraneous warnings generated by the ``ipython`` and ``ipython-posix`` directives when run from within Anaconda, since Windows users are likely to encounter tens of thousands of such warnings in a typical build.

Ideally, this PR will make it easier for Windows-based users to contribute to QuTiP by enabling local builds of the documentation.