### PR TITLE
Fix image positions in latex

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -206,6 +206,7 @@ latex_elements = {
                   'classoptions': '',
                   'babel': '\\usepackage[english]{babel}',
                   'fncychap' : '',
+                  'figure_align': 'H',
 #                  'preamble': PREAMBLE
 }
 

--- a/frontmatter.rst
+++ b/frontmatter.rst
@@ -77,14 +77,11 @@ Earlier development of QuTiP was partially supported by the Japanese Society for
 	:width: 1.5in
 	:figclass: align-center
 
-|
-
 .. _image-korea:
 
 .. figure:: figures/korea-logo.png
 	:width: 3in
 	:figclass: align-center
-
 
 .. _about:
 


### PR DESCRIPTION
Added the directive for aligning images using [H] in the PDF generated from Latex. Otherwise some of the images such as Riken logo, QuSTaR logo etc spilled over to the next page randomly with text in between. This fixes the issue, without affecting the Html in any way.