### PR TITLE
Small edit in the Floquet formalism guide to match the actual code snippet

### DIFF
--- a/guide/dynamics/dynamics-floquet.rst
+++ b/guide/dynamics/dynamics-floquet.rst
@@ -248,5 +248,5 @@ The other parameters are similar to the :func:`qutip.mesolve` and :func:`qutip.m
 
 Alternatively, we can let the :func:`qutip.floquet.fmmesolve` function transform the density matrix at each time step back to the computational basis, and calculating the expectation values for us, but using::
 
-    output = fmmesolve(H, psi0, times, [sigmax()], [num(2)], [noise_spectrum], T, args)
+    output = fmmesolve(H, psi0, tlist, [sigmax()], [num(2)], [noise_spectrum], T, args)
     p_ex = output.expect[0]


### PR DESCRIPTION
Last code snippet from http://qutip.org/docs/latest/guide/dynamics/dynamics-floquet.html#the-floquet-markov-master-equation-in-qutip uses `times` instead of `tlist` in the plotting code snippet. I think it can be misleading for newcomers, which would rather have some a snippet that could be directly copy/pasted.