### PR TITLE
Added API reference for qutip.scattering module

### DIFF
--- a/apidoc/functions.rst
+++ b/apidoc/functions.rst
@@ -185,6 +185,13 @@ Time-dependent problems
 .. automodule:: qutip.rhs_generate
     :members: rhs_generate, rhs_clear
 
+Scattering in Quantum Optical Systems
+-------------------------------------
+
+.. automodule:: qutip.scattering
+    :members: temporal_basis_vector, temporal_scattered_state, scattering_probability
+    :undoc-members:
+
 Visualization
 ===============
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,8 @@ Version 4.3.0 ()
 Improvements
 ------------
 
+- Added API reference for ``qutip.scattering`` module
+
 - Added fast projector method, ``Q.proj()``.
 
 - Computing matrix elements, ``Q.matrix_element`` is now ~10x faster.


### PR DESCRIPTION
This PR adds API reference for a new scattering module to QuTiP to compute temporal photon scattering in an arbitrarily-specified quantum optical systems, following the theoretical framework developed in K.A. Fischer, et.al. (2017), "Scattering of Coherent Pulses from Quantum-Optical Systems" (arXiv: 1710.02875). Look for accompanying pull requests in qutip (#848), qutip-notebooks, and qutip.github.io.