### PR TITLE
update link to Bloch sphere video

### DIFF
--- a/guide/guide-bloch.rst
+++ b/guide/guide-bloch.rst
@@ -493,7 +493,7 @@ The code to directly generate an mp4 movie of the Qubit decay is as follows::
 		
 	ani = animation.FuncAnimation(fig, animate, np.arange(len(sx)),
 	                            init_func=init, blit=True, repeat=False)
-	ani.save('bloch_sphere.mp4', fps=20, clear_temp=True)
+	ani.save('bloch_sphere.mp4', fps=20)
 
 
 The resulting movie may be viewed here: `bloch_decay.mp4 <https://github.com/qutip/qutip-doc/raw/master/figures/bloch_decay.mp4>`_

--- a/guide/guide-bloch.rst
+++ b/guide/guide-bloch.rst
@@ -496,5 +496,5 @@ The code to directly generate an mp4 movie of the Qubit decay is as follows::
 	ani.save('bloch_sphere.mp4', fps=20, clear_temp=True)
 
 
-The resulting movie may be viewed here: `Bloch_Decay.mp4 <http://qutip.googlecode.com/svn/doc/figures/bloch_decay.mp4>`_
+The resulting movie may be viewed here: `bloch_decay.mp4 <https://github.com/qutip/qutip-doc/raw/master/figures/bloch_decay.mp4>`_
 


### PR DESCRIPTION
Fix [Issue #800 opened in `qutip/qutip`](https://github.com/qutip/qutip/issues/800). Correct link to the Bloch sphere video decay. Actually a proper way to visualize the video in the html documentation might be given here,  https://stackoverflow.com/questions/48820321/how-to-force-a-file-mp4-to-transfer-from-github-to-readthedocs, but for now it is a fix of first order. 
