### PR TITLE
Fix duplicate entry in TOC

### DIFF
--- a/guide/guide-dynamics.rst
+++ b/guide/guide-dynamics.rst
@@ -15,7 +15,6 @@ Time Evolution and Quantum System Dynamics
    dynamics/dynamics-monte.rst
    dynamics/dynamics-photocurrent.rst
    dynamics/dynamics-stochastic.rst
-   dynamics/dynamics-monte.rst
    dynamics/dynamics-time.rst
    dynamics/dynamics-bloch-redfield.rst
    dynamics/dynamics-floquet.rst


### PR DESCRIPTION
'Monte Carlo Solver' appeared twice in the table of contents in the sidebar (issue #86). This is now fixed by removing the duplicate entry.