### PR TITLE
Update master_equation reference tag

### DIFF
--- a/guide/dynamics/dynamics-master.rst
+++ b/guide/dynamics/dynamics-master.rst
@@ -125,11 +125,11 @@ the equivalent of the Schrödinger equation :eq:`schrodinger` in the density mat
 includes the original system Hamiltonian :math:`H_{\rm sys}`, the Hamiltonian for the environment :math:`H_{\rm env}`, and a term representing the interaction between the system and its environment :math:`H_{\rm int}`. Since we are only interested in the dynamics of the system, we can at this point perform a partial trace over the environmental degrees of freedom in Eq. :eq:`neumann_total`, and thereby obtain a master equation for the motion of the original system density matrix. The most general trace-preserving and completely positive form of this evolution is the Lindblad master equation for the reduced density matrix :math:`\rho = {\rm Tr}_{\rm env}[\rho_{\rm tot}]`
 
 .. math::
-	:label: master_equation
+	:label: master_equation_lindblad
 
 	\dot\rho(t)=-\frac{i}{\hbar}[H(t),\rho(t)]+\sum_n \frac{1}{2} \left[2 C_n \rho(t) C_n^{+} - \rho(t) C_n^{+} C_n - C_n^{+} C_n \rho(t)\right]
 
-where the :math:`C_n = \sqrt{\gamma_n} A_n` are collapse operators, and :math:`A_n` are the operators through which the environment couples to the system in :math:`H_{\rm int}`, and :math:`\gamma_n` are the corresponding rates.  The derivation of Eq. :eq:`master_equation` may be found in several sources, and will not be reproduced here.  Instead, we emphasize the approximations that are required to arrive at the master equation in the form of Eq. :eq:`master_equation` from physical arguments, and hence perform a calculation in QuTiP:
+where the :math:`C_n = \sqrt{\gamma_n} A_n` are collapse operators, and :math:`A_n` are the operators through which the environment couples to the system in :math:`H_{\rm int}`, and :math:`\gamma_n` are the corresponding rates.  The derivation of Eq. :eq:`master_equation_lindblad` may be found in several sources, and will not be reproduced here.  Instead, we emphasize the approximations that are required to arrive at the master equation in the form of Eq. :eq:`master_equation_lindblad` from physical arguments, and hence perform a calculation in QuTiP:
 
 - **Separability:** At :math:`t=0` there are no correlations between the system and its environment such that the total density matrix can be written as a tensor product :math:`\rho^I_{\rm tot}(0) = \rho^I(0) \otimes \rho^I_{\rm env}(0)`.
 


### PR DESCRIPTION
The Lindblad master eq. reference tag at the [dynamics-master page](http://qutip.org/docs/latest/guide/dynamics/dynamics-master.html#equation-master-equation) was linking to the identically tagged eq. on the [dynamics-photocurrent](http://qutip.org/docs/latest/guide/dynamics/dynamics-photocurrent.html#equation-master-equation) page, and hence also displaying the incorrect equation number. 

Renamed the label in this page ('master_equation' -> 'master_equation_lindblad'), and updated the two in-text references to it

