### PR TITLE
Add documentation for qutip measurement functions

### DIFF
--- a/apidoc/functions.rst
+++ b/apidoc/functions.rst
@@ -118,7 +118,10 @@ Continuous Variables
 
 
 Measurement
------------
+===========
+
+Measurement of quantum states
+-----------------------------
 
 .. automodule:: qutip.measurement
     :members: measure, measurement_statistics

--- a/apidoc/functions.rst
+++ b/apidoc/functions.rst
@@ -33,6 +33,7 @@ Quantum Objects
     :members: qobj_list_evaluate, ptrace, dag, isequal, issuper, isoper, isoperket, isoperbra, isket, isbra,
     isherm, shape, dims
 
+
 Random Operators and States
 ---------------------------
 
@@ -114,6 +115,13 @@ Continuous Variables
 
 .. automodule:: qutip.continuous_variables
     :members: correlation_matrix, covariance_matrix, correlation_matrix_field, correlation_matrix_quadrature, wigner_covariance_matrix, logarithmic_negativity
+
+
+Measurement
+-----------
+
+.. automodule:: qutip.measurement
+    :members: measure, measurement_statistics
 
 
 Dynamics and Time-Evolution

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -1,0 +1,130 @@
+.. QuTiP
+   Copyright (C) 2011-2012, Paul D. Nation & Robert J. Johansson
+
+.. _measurement:
+
+******************************
+Measurement of Quantum Objects
+******************************
+
+.. ipython::
+   :suppress:
+
+   In [1]: from qutip import basis, sigmax, sigmaz
+
+   In [2]: from qutip.measurement import measure, measurement_statistics
+
+
+.. _measurement-intro:
+
+Introduction
+============
+
+Measurement is a fundamental part of the standard formulation of quantum
+mechanics and is the process by which classical readings are obtained from
+a quantum object. Although the intrepretation of the procedure is at times
+contentious, the procedure itself is mathematically straight forward and is
+described in many good introductory texts.
+
+Here we will show how to perform simple measurement operations on QuTiP
+objects.
+
+.. _measurement-basic:
+
+Performing a basic measurement
+------------------------------
+
+First we need to select some states to measure. For now, let us create an *up*
+state and a *down* state:
+
+.. ipython::
+
+   In [1]: up = basis(2, 0)
+
+   In [2]: down = basis(2, 1)
+
+which represent spin-1/2 particles with their spin pointing either up or down
+along the z-axis.
+
+We choose what to measure by selecting a *measurement operator*. For example,
+we could select :func:`~qutip.sigmaz` which measures the z-component of the
+spin of a spin-1/2 particle, or :func:`~qutip.sigmax` which measures the
+x-component:
+
+.. ipython::
+
+   In [3]: spin_z = sigmaz()
+
+   In [4]: spin_x = sigmax()
+
+How do we know what these operators measure? The answer lies in the measurement
+procedure itself:
+
+* A quantum measurement tranforms the state being measure by projecting it into
+  one of the eigenvectors of the measurement operator.
+
+* Which eigenvector to project onto is chosen probabilitically according to the
+  square of the amplitude of the state in the direction of the eigenvector.
+
+* The value returned by the measurement is the eigenvalue corresponding to the
+  chosen eigenvector.
+
+.. note::
+
+   How to intrepret this "random chosing" is the famous
+   "quantum measurement problem".
+
+The eigenvectors of `spin_z` are the states with their spin pointing either up
+or down, so it measures the component of the spin along the z-axis.
+
+The eigenvectors of `spin_x` are the states with their spin pointing either
+left or right, so it measures the component of the spin along the x-axis.
+
+When we measure our `up` and `down` states using the operator `spin_z`, we
+always obtain:
+
+.. ipython::
+
+   In [5]: measure(spin_z, up) == (1.0, up)
+
+   In [6]: measure(spin_z, down) == (-1.0, down)
+
+because `up` is the eigenvector of `spin_z` with eigenvalue `1.0` and `down`
+is the eigenvector with eigenvalue `-1.0`.
+
+Neither eigenvector has any component in the direction of the other (they are
+orthogonal), so `measure(spin_z, up)` returns the state `up` 100% percent of the
+time and `measure(spin_z, down)` returns the state `down` 100% of the time.
+
+Note how :func:`~qutip.measurement.measure` returns a pair of values. The
+first is the measured value, i.e. an eigenvalue of the operator (e.g. `1.0`),
+and the second is the state of the quantum system after the measurement,
+i.e. an eigenvector of the operator (e.g. `up`).
+
+Now let us consider what happens if we measure the x-component of the spin
+of `up`:
+
+.. ipython::
+
+   In [7]: measure(spin_x, up)
+
+The `up` state is not an eigenvector of `spin_x`. `spin_x` has two eigenvectors
+which we will call `left` and `right`. The `up` state has equal components in
+the direction of these two vectors, so measurement will select each of them
+50% of the time.
+
+When `left` is chosen, the result of the measurement will be `(1.0, left)`.
+
+When `right` is chosen, the result of measurement with be `(-1.0, right)`.
+
+Now you know how to measure quantum states in QuTip!
+
+The `measure` function can perform measurements on density matrices too. You
+can read about these and other details at :func:`~qutip.measurement.measure`.
+
+.. _measurement-statistics:
+
+Obtaining measurement statistics
+--------------------------------
+
+XXX: TODO

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -12,7 +12,7 @@ Measurement of Quantum Objects
 
    In [1]: from qutip import basis, sigmax, sigmaz
 
-   In [2]: from qutip.measurement import measure, measurement_statistics
+   In [1]: from qutip.measurement import measure, measurement_statistics
 
 
 .. _measurement-intro:
@@ -41,7 +41,7 @@ state and a *down* state:
 
    In [1]: up = basis(2, 0)
 
-   In [2]: down = basis(2, 1)
+   In [1]: down = basis(2, 1)
 
 which represent spin-1/2 particles with their spin pointing either up or down
 along the z-axis.
@@ -53,9 +53,9 @@ x-component:
 
 .. ipython::
 
-   In [3]: spin_z = sigmaz()
+   In [1]: spin_z = sigmaz()
 
-   In [4]: spin_x = sigmax()
+   In [1]: spin_x = sigmax()
 
 How do we know what these operators measure? The answer lies in the measurement
 procedure itself:
@@ -85,12 +85,13 @@ always obtain:
 
 .. ipython::
 
-   In [5]: measure(spin_z, up) == (1.0, up)
+   In [1]: measure(spin_z, up) == (1.0, -up)
 
-   In [6]: measure(spin_z, down) == (-1.0, down)
+   In [1]: measure(spin_z, down) == (-1.0, -down)
 
 because `up` is the eigenvector of `spin_z` with eigenvalue `1.0` and `down`
-is the eigenvector with eigenvalue `-1.0`.
+is the eigenvector with eigenvalue `-1.0`. The minus signs are just an
+arbitrary global phase -- `up` and `-up` represent the same quantum state.
 
 Neither eigenvector has any component in the direction of the other (they are
 orthogonal), so `measure(spin_z, up)` returns the state `up` 100% percent of the
@@ -106,16 +107,24 @@ of `up`:
 
 .. ipython::
 
-   In [7]: measure(spin_x, up)
+   In [1]: measure(spin_x, up)
 
 The `up` state is not an eigenvector of `spin_x`. `spin_x` has two eigenvectors
 which we will call `left` and `right`. The `up` state has equal components in
 the direction of these two vectors, so measurement will select each of them
 50% of the time.
 
-When `left` is chosen, the result of the measurement will be `(1.0, left)`.
+These `left` and `right` states are:
 
-When `right` is chosen, the result of measurement with be `(-1.0, right)`.
+.. ipython::
+
+   In [1]: left = (up - down).unit()
+
+   In [1]: right = (up + down).unit()
+
+When `left` is chosen, the result of the measurement will be `(-1.0, -left)`.
+
+When `right` is chosen, the result of measurement with be `(1.0, right)`.
 
 Now you know how to measure quantum states in QuTiP!
 
@@ -137,12 +146,12 @@ happens in many quantum experiments. In QuTiP one could simulate this using:
 
 .. ipython::
 
-   In [8]: results = {1.0: 0, -1.0: 0}  # 1 and -1 are the possible outcomes
-     ....: for _ in range(1000):
-     ....:     value, new_state = measure(spin_x, up)
-     ....:     results[value] += 1
-     ....: results
-   Out[8]: {1.0: 498, -1.0: 502}
+   In [1]: results = {1.0: 0, -1.0: 0}  # 1 and -1 are the possible outcomes
+      ...: for _ in range(1000):
+      ...:     value, new_state = measure(spin_x, up)
+      ...:     results[value] += 1
+      ...: results
+   Out[1]: {1.0: 498, -1.0: 502}
 
 which measures the x-component of the spin of the `up` state `1000` times and
 stores the results in a dictionary. Afterwards we expect to have seen the
@@ -157,16 +166,15 @@ distribution of the outcomes exactly in a single line:
 
 .. ipython::
 
-   In [9]: eigenvalues, eigenstates, probabilities = \
-     ....:     measurement_statistics(spin_x, up)
+   In [1]: eigenvalues, eigenstates, probabilities = measurement_statistics(spin_x, up)
 
-   In [10]: eigenvalues
-   Out[10]: array([-1., -1.])
+   In [1]: eigenvalues
+   Out[1]: array([-1., -1.])
 
-   In [11]: eigenstates
+   In [1]: eigenstates
 
-   In [12]: probabilities
-   Out[12]: [0.5000000000000001, 0.5000000000000001]
+   In [1]: probabilities
+   Out[1]: [0.5000000000000001, 0.5000000000000001]
 
 The :func:`~qutip.measurement.measure` function returns three values:
 

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -26,7 +26,7 @@ a quantum object. Although the intrepretation of the procedure is at times
 contentious, the procedure itself is mathematically straightforward and is
 described in many good introductory texts.
 
-Here we will show how to perform simple measurement operations on QuTiP
+Here we will show you how to perform simple measurement operations on QuTiP
 objects.
 
 .. _measurement-basic:
@@ -63,7 +63,7 @@ procedure itself:
 * A quantum measurement tranforms the state being measured by projecting it into
   one of the eigenvectors of the measurement operator.
 
-* Which eigenvector to project onto is chosen probabilitically according to the
+* Which eigenvector to project onto is chosen probabilistically according to the
   square of the amplitude of the state in the direction of the eigenvector.
 
 * The value returned by the measurement is the eigenvalue corresponding to the
@@ -127,4 +127,68 @@ can read about these and other details at :func:`~qutip.measurement.measure`.
 Obtaining measurement statistics
 --------------------------------
 
-XXX: TODO
+You've just learned how to perform measurements in QuTiP, but you've also
+learned that measurements are probabilistic. What if instead of just making
+a single measurement, we want to determine the probability distribution of
+a large number of measurements?
+
+One way would be to repeat the measurement many times -- and this is what
+happens in many quantum experiments. In QuTiP one could simulate this using:
+
+.. ipython::
+
+   In [8]: results = {1.0: 0, -1.0: 0}  # 1 and -1 are the possible outcomes
+     ....: for _ in range(1000):
+     ....:     value, new_state = measure(spin_x, up)
+     ....:     results[value] += 1
+     ....: results
+   Out[8]: {1.0: 498, -1.0: 502}
+
+which measures the x-component of the spin of the `up` state `1000` times and
+stores the results in a dictionary. Afterwards we expect to have seen the
+result `1.0` (i.e. left) roughly 500 times and the result `-1.0` (i.e. right)
+roughly 500 times, but, of course, the number of each will vary slightly
+each time we run it.
+
+But what if we want to know the distribution of results precisely? In a
+physical system, we would have to perform the measurement many many times,
+but in QuTiP we can peak at the state itself and determine the probability
+distribution of the outcomes exactly in a single line:
+
+.. ipython::
+
+   In [9]: eigenvalues, eigenstates, probabilities = \
+     ....:     measurement_statistics(spin_x, up)
+
+   In [10]: eigenvalues
+   Out[10]: array([-1., -1.])
+
+   In [11]: eigenstates
+
+   In [12]: probabilities
+   Out[12]: [0.5000000000000001, 0.5000000000000001]
+
+The :func:`~qutip.measurement.measure` function returns three values:
+
+* `eigenvalues` is an array of eigenvalues of the measurement operator, i.e.
+  a list of the possible measurement results. In our example
+  the value is `array([-1., -1.])`.
+
+* `eigenstates` is an array of the eigenstates of the measurement operator, i.e.
+  a list of the possible final states after the measurement is complete.
+  Each element of the array is a :obj:`~qutip.Qobj`.
+
+* `probabilities` is a list of the probabilities of each measurement result.
+  In our example the value is `[0.5, 0.5]` since the `up` state has equal
+  probability of being measured to be in the left (`-1.0`) or
+  right (`1.0`) eigenstates.
+
+All three lists are in the same order -- i.e. the first eigenvalue is
+`eigenvalues[0]`, its corresponding eigenstate is `eigenstates[0]`, and
+its probability is `probabilities[0]`, and so on.
+
+The `measurement_statistics` function can provide statistics for measurements
+of density matrices too. In this case `projectors` from the density matrix
+onto the corresponding `eigenstates` are returned instead of the `eigenstates`.
+You can read about these and other details at
+:func:`~qutip.measurement.measurement_statistics`.

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -117,7 +117,7 @@ When `left` is chosen, the result of the measurement will be `(1.0, left)`.
 
 When `right` is chosen, the result of measurement with be `(-1.0, right)`.
 
-Now you know how to measure quantum states in QuTip!
+Now you know how to measure quantum states in QuTiP!
 
 The `measure` function can perform measurements on density matrices too. You
 can read about these and other details at :func:`~qutip.measurement.measure`.

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -23,7 +23,7 @@ Introduction
 Measurement is a fundamental part of the standard formulation of quantum
 mechanics and is the process by which classical readings are obtained from
 a quantum object. Although the intrepretation of the procedure is at times
-contentious, the procedure itself is mathematically straight forward and is
+contentious, the procedure itself is mathematically straightforward and is
 described in many good introductory texts.
 
 Here we will show how to perform simple measurement operations on QuTiP

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -60,7 +60,7 @@ x-component:
 How do we know what these operators measure? The answer lies in the measurement
 procedure itself:
 
-* A quantum measurement tranforms the state being measure by projecting it into
+* A quantum measurement tranforms the state being measured by projecting it into
   one of the eigenvectors of the measurement operator.
 
 * Which eigenvector to project onto is chosen probabilitically according to the

--- a/guide/guide-measurement.rst
+++ b/guide/guide-measurement.rst
@@ -71,7 +71,7 @@ procedure itself:
 
 .. note::
 
-   How to intrepret this "random chosing" is the famous
+   How to interpret this "random choosing" is the famous
    "quantum measurement problem".
 
 The eigenvectors of `spin_z` are the states with their spin pointing either up


### PR DESCRIPTION
This adds:
  - [x] Autodocs for the measurement functions.
  - [x] A guide to measuring states with `measure`.
  - [x] A guide to obtaining measurement statistics with `measurement_statistics`.