### PR TITLE
Add changelog for 4.6.0 (and backdated 4.5.2, 4.5.1)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,11 +1,24 @@
 .. QuTiP
-   Copyright (C) 2011-2020, Paul D. Nation, Robert J. Johansson, Alexander Pitchford, Chris Granade, Arne Grimsmo, Nathan Shammah, Shahnawax Ahmed, Eric Giguère
+   Copyright (C) 2011-2020, Paul D. Nation, Robert J. Johansson, Alexander Pitchford, Chris Granade, Arne Grimsmo, Nathan Shammah, Shahnawaz Ahmed, Jake Lishman, and Eric Giguère
 
 .. _changelog:
 
 **********
 Change Log
 **********
+
+Version 4.5.3 (February 19, 2021)
++++++++++++++++++++++++++++++++++
+
+This patch release adds support for Numpy 1.20, made necessary by changes to how array-like objects are handled. There are no other changes relative to version 4.5.2.
+
+Users building from source should ensure that they build against Numpy versions >= 1.16.6 and < 1.20 (not including 1.20 itself), but after that or for those installing from conda, an installation will support any current Numpy version >= 1.16.6.
+
+Improvements
+------------
+- Add support for Numpy 1.20.  QuTiP should be compiled against a version of Numpy ``>= 1.16.6`` and ``< 1.20`` (note: does _not_ include 1.20 itself), but such an installation is compatible with any modern version of Numpy.  Source installations from ``pip`` understand this constraint.
+
+
 
 Version 4.5.2 (July 14, 2020)
 +++++++++++++++++++++++++++++

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,60 @@
 Change Log
 **********
 
+Version 4.5.2 (July 14, 2020)
++++++++++++++++++++++++++++++
+
+This is predominantly a hot-fix release to add support for Scipy 1.5, due to changes in private sparse matrix functions that QuTiP also used.
+
+Improvements
+------------
+- Add support for Scipy 1.5. (by **Jake Lishman**)
+- Improved speed of ``zcsr_inner``, which affects ``Qobj.overlap``. (by **Jake Lishman**)
+- Better error messages when installation requirements are not satisfied. (by **Eric Giguère**)
+
+Bug Fixes
+---------
+- Fix ``zcsr_proj`` acting on matrices with unsorted indices.  (by **Jake Lishman**)
+- Fix errors in Milstein's heterodyne. (by **Eric Giguère**)
+- Fix datatype bug in ``qutip.lattice`` module. (by **Boxi Li**)
+- Fix issues with ``eigh`` on Mac when using OpenBLAS.  (by **Eric Giguère**)
+
+Developer Changes
+-----------------
+- Converted more of the codebase to PEP 8.
+- Fix several instances of unsafe mutable default values and unsafe ``is`` comparisons.
+
+
+
+Version 4.5.1 (May 15, 2020)
+++++++++++++++++++++++++++++
+
+Improvements
+------------
+- ``husimi`` and ``wigner`` now accept half-integer spin (by **maij**)
+- Better error messages for failed string coefficient compilation. (issue raised by **nohchangsuk**)
+
+Bug Fixes
+---------
+- Safer naming for temporary files. (by **Eric Giguère**)
+- Fix ``clebsch`` function for half-integer (by **Thomas Walker**)
+- Fix ``randint``'s dtype to ``uint32`` for compatibility with Windows. (issue raised by **Boxi Li**)
+- Corrected stochastic's heterodyne's m_ops (by **eliegenois**)
+- Mac pool use spawn. (issue raised by **goerz**)
+- Fix typos in ``QobjEvo._shift``. (by **Eric Giguère**)
+- Fix warning on Travis CI. (by **Ivan Carvalho**)
+
+Deprecations
+------------
+- ``qutip.graph`` functions will be deprecated in QuTiP 5.0 in favour of ``scipy.sparse.csgraph``.
+
+Developer Changes
+-----------------
+- Add Boxi Li to authors. (by **Alex Pitchford**)
+- Skip some tests that cause segfaults on Mac. (by **Nathan Shammah** and **Eric Giguère**)
+- Use Python 3.8 for testing on Mac and Linux. (by **Simon Cross** and **Eric Giguère**)
+
+
 
 Version 4.5.0 (January 31, 2020)
 ++++++++++++++++++++++++++++++

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,63 @@
 Change Log
 **********
 
+Version 4.6.0 (April 10, 2021)
++++++++++++++++++++++++++++++++++
+
+This release brings improvements for qubit circuits, including a pulse scheduler, measurement statistics, reading/writing OpenQASM and optimisations in the circuit simulations.
+
+This is the first release to have full binary wheel releases on pip; you can now do ``pip install qutip`` on almost any machine to get a correct version of the package without needing any compilers set up.
+The support for Numpy 1.20 that was first added in QuTiP 4.5.3 is present in this version as well, and the same build considerations mentioned there apply here too.
+If building using the now-supported PEP 517 mechanisms (e.g. ``python -mbuild /path/to/qutip``), all build dependencies will be correctly satisfied.
+
+Improvements
+------------
+- **MAJOR** Add saving, loading and resetting functionality to ``qutip.settings`` for easy re-configuration. (by **Eric Giguère**)
+- **MAJOR** Add a quantum gate scheduler in ``qutip.qip.scheduler``, to help parallelise the operations of quantum gates.  This supports two scheduling modes: as late as possible, and as soon as possible. (by **Boxi Li**)
+- **MAJOR** Improved qubit circuit simulators, including OpenQASM support and performance optimisations. (by **Sidhant Saraogi**)
+- **MAJOR** Add tools for quantum measurements and their statistics. (by **Simon Cross** and **Sidhant Saraogi**)
+- Add support for Numpy 1.20.  QuTiP should be compiled against a version of Numpy ``>= 1.16.6`` and ``< 1.20`` (note: does _not_ include 1.20 itself), but such an installation is compatible with any modern version of Numpy.  Source installations from ``pip`` understand this constraint.
+- Improve the error message when circuit plotting fails. (by **Boxi Li**)
+- Add support for parsing M1 Mac hardware information. (by **Xiaoliang Wu**)
+- Add more single-qubit gates and controlled gates. (by **Mateo Laguna** and **Martín Sande Costa**)
+- Support decomposition of ``X``, ``Y`` and ``Z`` gates in circuits. (by **Boxi Li**)
+- Refactor ``QubitCircuit.resolve_gate()`` (by **Martín Sande Costa**)
+
+Bug Fixes
+---------
+- Fix ``dims`` in the returns from ``Qobj.eigenstates`` on superoperators. (by **Jake Lishman**)
+- Calling Numpy ufuncs on ``Qobj`` will now correctly raise a ``TypeError`` rather than returning a nonsense ``ndarray``. (by **Jake Lishman**)
+- Convert segfault into Python exception when creating too-large tensor products. (by **Jake Lishman**)
+- Correctly set ``num_collapse`` in the output of ``mesolve``. (by **Jake Lishman**)
+- Fix ``ptrace`` when all subspaces are being kept, or the subspaces are passed in order. (by **Jake Lishman**)
+- Fix sorting bug in ``Bloch3d.add_points()``. (by **pschindler**)
+- Fix invalid string literals in docstrings and some unclosed files. (by **Élie Gouzien**)
+- Fix Hermicity tests for matrices with values that are within the tolerance of 0. (by **Jake Lishman**)
+- Fix the trace norm being incorrectly reported as 0 for small matrices. (by **Jake Lishman**)
+- Fix issues with ``dnorm`` when using CVXPy 1.1 with sparse matrices. (by **Felipe Bivort Haiek**)
+- Fix segfaults in ``mesolve`` when passed a bad initial ``Qobj`` as the state. (by **Jake Lishman**)
+- Fix sparse matrix construction in PIQS when using Scipy 1.6.1. (by **Drew Parsons**)
+- Fix ``zspmv_openmp.cpp`` missing from the pip sdist. (by **Christoph Gohlke**)
+- Fix correlation functions throwing away imaginary components. (by **Asier Galicia Martinez**)
+- Fix ``QubitCircuit.add_circuit()`` for SWAP gate. (by **Canoming**)
+- Fix the broken LaTeX image conversion. (by **Jake Lishman**)
+
+Deprecations
+------------
+- ``eseries``, ``essolve`` and ``ode2es`` are all deprecated, pending removal in QuTiP 5.0.  These are legacy functions and classes that have been left unmaintained for a long time, and their functionality is now better achieved with ``QobjEvo`` or ``mesolve``.
+
+Developer Changes
+-----------------
+- **MAJOR** Overhaul of setup and packaging code to make it satisfy PEP 517, and move the build to a matrix on GitHub Actions in order to release binary wheels on pip for all major platforms and supported Python versions. (by **Jake Lishman**)
+- Default arguments in ``Qobj`` are now ``None`` rather than mutable types. (by **Jake Lishman**)
+- Fixed comsumable iterators being used to parametrise some tests, preventing the testing suite from being re-run within the same session. (by **Jake Lishman**)
+- Remove unused imports, simplify some floats and remove unnecessary list conversions. (by **jakobjakobson13**)
+- Improve Travis jobs matrix for specifying the testing containers. (by **Jake Lishman**)
+- Fix coverage reporting on Travis. (by **Jake Lishman**)
+- Added a ``pyproject.toml`` file. (by **Simon Humpohl** and **Eric Giguère**)
+
+
+
 Version 4.5.3 (February 19, 2021)
 +++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
This is the proposed changelog for what will be in the new release.  I originally thought this would be a 4.5.3 release, but looking through the features, it really is more like 4.6.0 if we release branched directly off the present-day master, as I had suggested in the emails.  There's plenty of bug-fixes and whatnot included too.

I'm proposing to release most of Sidhant's work from GSoC, Boxi's pulse scheduler and Eric's upgrade to the settings machinery here, along with the support for Numpy 1.20 and a bunch of bug fixes.

Probably the major concern with going to 4.6 is documentation.  We urgently need to merge #117 (Sidhant's docs) and gain documentation for Boxi's scheduler.  I'll also need to go through and check the API-doc sections.  My understanding is that a lot of Eric's settings changes are actually documented already, we just never fulfilled that part of the spec...

If we do decide to go through with this and Sidhant isn't available, I'll rebase his PR, make Boxi's changes and apply it directly.

The prospective release branch exists on the main repository will be `qutip-4.6.X`.