### PR TITLE
Changed link  in guide-tensor to correct superop-contract notebook

### DIFF
--- a/guide/guide-tensor.rst
+++ b/guide/guide-tensor.rst
@@ -438,4 +438,4 @@ operators:
 
 
 
-.. _channel contraction tutorial: http://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/example-superop-contract.ipynb
+.. _channel contraction tutorial: http://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/superop-contract.ipynb


### PR DESCRIPTION
This solves this issue https://github.com/qutip/qutip-notebooks/issues/126