### PR TITLE
Build docs as an action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build HTML documentation
+
+on:
+  [push, pull_request]
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install documentation dependencies
+        run: |
+          python -mpip install -r requirements.txt
+
+      - name: Install QuTiP from GitHub
+        run: |
+          python -mpip install git+git://github.com/qutip/qutip.git#egg=qutip[full]
+          python -c 'import qutip; qutip.about()'
+
+      - name: Build documentation
+        run: |
+          make html SPHINXOPTS="-W --keep-going -T"
+          # Above flags are:
+          #   -W : turn warnings into errors
+          #   --keep-going : do not stop after the first error
+          #   -T : display a full traceback if a Python exception occurs
+
+      - name: Upload built files
+        uses: actions/upload-artifact@v2
+        with:
+          name: qutip_html_docs
+          path: _build/html/*
+          if-no-files-found: error


### PR DESCRIPTION
This is intended as a CI test of the documentation build; it treats warnings in the Sphinx build as errors, so we don't accidentally break anything on new PRs.

This is not perfect.  Most errors will come from problems in the main QuTiP repository's API documentation (docstrings).  These will only be caught on the next documentation build, which may cause some minor problems for contributors to the docs repository, but hopefully we will at least catch them and get them fixed again.

Once qutip-doc is merged into qutip/qutip these strange cross-repository annoyances will go away.
